### PR TITLE
Add Valgrind

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ jobs:
       - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: 'devel'
+      - name: Install Dependencies
+        run: sudo apt-get install --no-install-recommends -yq valgrind
       - uses: juancarlospaco/nimrun-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/index.js
+++ b/index.js
@@ -177,16 +177,18 @@ function parseGithubCommand(comment) {
   if (result.startsWith("!nim js")) {
     result = result + " -d:nodejs -d:nimExperimentalAsyncjsThen -d:nimExperimentalJsfetch "
   }
-  if (hasArc(result)) {
+  const useArc      = hasArc(result)
+  const useValgrind = useArc && hasMalloc(result)
+  if (useArc) {
     result = result + " -d:nimArcDebug -d:nimArcIds "
   }
-  if (hasMalloc(result)) {
+  if (useValgrind) {
     result = result + " -d:nimAllocPagesViaMalloc -d:useSysAssert -d:useGcAssert -d:nimLeakDetector --debugger:native --debuginfo:on "
   } else {
     result = result + " --run "
   }
   result = result + extraFlags
-  if (hasMalloc(result)) {
+  if (useValgrind) {
     result = result + ` && valgrind ${temporaryOutFile}`
   }
   result = result.substring(1) // Remove the leading "!"


### PR DESCRIPTION
- Add Valgrind for C and C++ targets to find memory leaks ASAP. JS just uses `--run`.
- This can be reverted if the Valgrind does not work or is not needed in the future.

# Use

- Iff using ARC/ORC/AtomicARC and useMalloc then uses Valgrind.
- Example `!nim c --gc:arc -d:useMalloc` (automatically sets `--debugger:native` etc).

#### Requisites

- Needs https://github.com/nim-lang/Nim/pull/22346 to be merged first!.

#### Why?

- https://github.com/nim-lang/Nim/issues/22255#issuecomment-1646974743

#### Features

- Valgrind ➡️ https://github.com/juancarlospaco/nimrun-action/pull/4/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R180-R186
- GCC versions etc ➡️ https://github.com/juancarlospaco/nimrun-action/pull/4/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R103-R111
- Nim 2.0 ➡️ https://github.com/juancarlospaco/nimrun-action/commit/39ca00925e64c3870dec08ba6a39b08a7b8144a5


@ringabout Feel free to revert if you see any problems.
